### PR TITLE
Update dependency in manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4857,7 +4857,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "valence-account-utils"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -4872,7 +4872,7 @@ dependencies = [
 [[package]]
 name = "valence-astroport-lper"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -4886,7 +4886,7 @@ dependencies = [
 [[package]]
 name = "valence-astroport-utils"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -4896,7 +4896,7 @@ dependencies = [
 [[package]]
 name = "valence-astroport-withdrawer"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -4911,7 +4911,7 @@ dependencies = [
 [[package]]
 name = "valence-authorization"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmos-sdk-proto 0.20.0",
  "cosmwasm-schema 2.2.1",
@@ -4933,7 +4933,7 @@ dependencies = [
 [[package]]
 name = "valence-authorization-utils"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -4947,7 +4947,7 @@ dependencies = [
 [[package]]
 name = "valence-base-account"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -4963,7 +4963,7 @@ dependencies = [
 [[package]]
 name = "valence-drop-liquid-staker"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -4981,7 +4981,7 @@ dependencies = [
 [[package]]
 name = "valence-drop-liquid-unstaker"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5001,7 +5001,7 @@ dependencies = [
 [[package]]
 name = "valence-encoder-broker"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5015,7 +5015,7 @@ dependencies = [
 [[package]]
 name = "valence-encoder-utils"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "alloy-sol-types",
  "cosmwasm-schema 2.2.1",
@@ -5026,7 +5026,7 @@ dependencies = [
 [[package]]
 name = "valence-forwarder-library"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5045,7 +5045,7 @@ dependencies = [
 [[package]]
 name = "valence-generic-ibc-transfer-library"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5065,7 +5065,7 @@ dependencies = [
 [[package]]
 name = "valence-gmp-utils"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5074,7 +5074,7 @@ dependencies = [
 [[package]]
 name = "valence-ibc-utils"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmos-sdk-proto 0.20.0",
  "cosmwasm-schema 2.2.1",
@@ -5088,7 +5088,7 @@ dependencies = [
 [[package]]
 name = "valence-library-base"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5105,7 +5105,7 @@ dependencies = [
 [[package]]
 name = "valence-library-utils"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5123,7 +5123,7 @@ dependencies = [
 [[package]]
 name = "valence-liquid-staking-utils"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5132,7 +5132,7 @@ dependencies = [
 [[package]]
 name = "valence-macros"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5144,7 +5144,7 @@ dependencies = [
 [[package]]
 name = "valence-middleware-broker"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5164,7 +5164,7 @@ dependencies = [
 [[package]]
 name = "valence-middleware-utils"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5177,7 +5177,7 @@ dependencies = [
 [[package]]
 name = "valence-neutron-ibc-transfer-library"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5199,7 +5199,7 @@ dependencies = [
 [[package]]
 name = "valence-neutron-ic-querier"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5219,7 +5219,7 @@ dependencies = [
 [[package]]
 name = "valence-osmosis-cl-lper"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5241,7 +5241,7 @@ dependencies = [
 [[package]]
 name = "valence-osmosis-cl-withdrawer"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5263,7 +5263,7 @@ dependencies = [
 [[package]]
 name = "valence-osmosis-gamm-lper"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5279,7 +5279,7 @@ dependencies = [
 [[package]]
 name = "valence-osmosis-gamm-withdrawer"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5295,7 +5295,7 @@ dependencies = [
 [[package]]
 name = "valence-osmosis-utils"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5307,7 +5307,7 @@ dependencies = [
 [[package]]
 name = "valence-processor"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5324,7 +5324,7 @@ dependencies = [
 [[package]]
 name = "valence-processor-utils"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5339,7 +5339,7 @@ dependencies = [
 [[package]]
 name = "valence-program-manager"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -5398,7 +5398,7 @@ dependencies = [
 [[package]]
 name = "valence-program-registry"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5414,7 +5414,7 @@ dependencies = [
 [[package]]
 name = "valence-program-registry-utils"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5425,7 +5425,7 @@ dependencies = [
 [[package]]
 name = "valence-reverse-splitter-library"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5444,7 +5444,7 @@ dependencies = [
 [[package]]
 name = "valence-splitter-library"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",
@@ -5464,7 +5464,7 @@ dependencies = [
 [[package]]
 name = "valence-storage-account"
 version = "0.2.0"
-source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#ea55e8c8a7cf9132d81ff8b74aa2d0b1473cd279"
+source = "git+https://github.com/timewave-computer/valence-protocol?branch=art3mix%2Fmanager-env-admin#cb45980bdb74ee8a400c1b1085951e7978e1774e"
 dependencies = [
  "cosmwasm-schema 2.2.1",
  "cosmwasm-std 2.2.1",


### PR DESCRIPTION
We were getting an error when deploying, because writing to the registry required you to be the owner of the registry. This was updated to be permissionless, and we had to update the manager dependency to use the correct deploy logic.